### PR TITLE
fix: rename prop to match histoire variant component

### DIFF
--- a/playground/components/NuxtBadge.story.vue
+++ b/playground/components/NuxtBadge.story.vue
@@ -1,10 +1,10 @@
 <template>
   <Story>
-    <Variant name="Default">
+    <Variant title="Default">
       <UBadge>Badge</UBadge>
     </Variant>
 
-    <Variant name="Class Overrides">
+    <Variant title="Class Overrides">
       <UBadge class="font-bold rounded-full">
         Badge
       </UBadge>

--- a/playground/components/NuxtButton.story.vue
+++ b/playground/components/NuxtButton.story.vue
@@ -1,10 +1,10 @@
 <template>
   <Story>
-    <Variant name="Default">
+    <Variant title="Default">
       <UButton>Button</UButton>
     </Variant>
 
-    <Variant name="Class Overrides">
+    <Variant title="Class Overrides">
       <UButton class="font-bold rounded-full">
         Button
       </UButton>

--- a/src/module.ts
+++ b/src/module.ts
@@ -32,10 +32,10 @@ function cleanTemplate(template: string) {
 function extractVariantContent(variantNode: ElementNode, template: string) {
   if (!variantNode.children) return null
 
-  // Get the name prop
-  const props = variantNode.props?.find(p => p.name === 'name')
-  const name = props?.type === 6 ? props.value?.content || '' : ''
-  if (!name) return null
+  // Get the title prop
+  const props = variantNode.props?.find(p => p.name === 'title')
+  const title = props?.type === 6 ? props.value?.content || '' : ''
+  if (!title) return null
 
   // Get the slot content
   const content = variantNode.children
@@ -49,7 +49,7 @@ function extractVariantContent(variantNode: ElementNode, template: string) {
     .filter(Boolean)
     .join('\n')
 
-  return { name, content }
+  return { title, content }
 }
 
 // Extract story content from template
@@ -101,12 +101,12 @@ function extractStoryContent(template: string, filename: string, id: string) {
   // Process variants
   const processedVariants = variantNodes
     .map(node => extractVariantContent(node, template))
-    .filter((v): v is { name: string, content: string } => v !== null)
+    .filter((v): v is { title: string, content: string } => v !== null)
 
   // Store variant templates
   const variants: Record<string, string> = {}
-  processedVariants.forEach(({ name, content }) => {
-    variants[name] = cleanTemplate(content)
+  processedVariants.forEach(({ title, content }) => {
+    variants[title] = cleanTemplate(content)
   })
 
   return { template: null, variants }

--- a/src/runtime/components/Variant.vue
+++ b/src/runtime/components/Variant.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="variant">
     <h2 class="variant-title">
-      {{ name }}
+      {{ title }}
     </h2>
     <div class="variant-content">
       <slot />
@@ -23,7 +23,7 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<{
-  name: string
+  title: string
   showTemplate?: boolean
 }>(), {
   showTemplate: true,
@@ -32,7 +32,7 @@ const props = withDefaults(defineProps<{
 const storySlug = inject<string | undefined>('story-slug')
 const { getTemplate } = useStory()
 const variantTemplateCode = computed(() =>
-  storySlug ? getTemplate(storySlug, props.name) : null,
+  storySlug ? getTemplate(storySlug, props.title) : null,
 )
 </script>
 

--- a/test/fixtures/basic/components/BaseButton.story.vue
+++ b/test/fixtures/basic/components/BaseButton.story.vue
@@ -1,9 +1,9 @@
 <template>
   <Story title="Button Component">
-    <Variant name="Default">
+    <Variant title="Default">
       <button>Click me</button>
     </Variant>
-    <Variant name="Disabled">
+    <Variant title="Disabled">
       <button disabled>
         Click me
       </button>

--- a/test/fixtures/custom-route/components/BaseButton.story.vue
+++ b/test/fixtures/custom-route/components/BaseButton.story.vue
@@ -1,9 +1,9 @@
 <template>
   <Story title="Button Component">
-    <Variant name="Default">
+    <Variant title="Default">
       <button>Click me</button>
     </Variant>
-    <Variant name="Disabled">
+    <Variant title="Disabled">
       <button disabled>
         Click me
       </button>

--- a/test/fixtures/layers/base/stories/BaseButton.story.vue
+++ b/test/fixtures/layers/base/stories/BaseButton.story.vue
@@ -1,9 +1,9 @@
 <template>
   <Story title="Base Button">
-    <Variant name="Default">
+    <Variant title="Default">
       <button>Base Button</button>
     </Variant>
-    <Variant name="Disabled">
+    <Variant title="Disabled">
       <button disabled>
         Base Button
       </button>

--- a/test/fixtures/layers/feature-a/stories/FeatureAButton.story.vue
+++ b/test/fixtures/layers/feature-a/stories/FeatureAButton.story.vue
@@ -1,6 +1,6 @@
 <template>
   <Story title="Feature A Button">
-    <Variant name="Default">
+    <Variant title="Default">
       <button>Feature A Button</button>
     </Variant>
   </Story>

--- a/test/fixtures/layers/feature-b/stories/FeatureBButton.story.vue
+++ b/test/fixtures/layers/feature-b/stories/FeatureBButton.story.vue
@@ -1,6 +1,6 @@
 <template>
   <Story title="Feature B Button">
-    <Variant name="Default">
+    <Variant title="Default">
       <button>Feature B Button</button>
     </Variant>
   </Story>


### PR DESCRIPTION
This renames the Variant component prop name to title, making this more of a drop-in replacement of Histoire than previously.