### PR TITLE
perf: async components

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -128,8 +128,6 @@ export {}
     addTemplate({
       filename: 'stories.mjs',
       getContents: () => `
-${stories.map(s => `import ${s.pascalName} from '${s.filePath}'`).join('\n')}
-
 export const stories = {
 ${stories.map(s => `  '${s.kebabName}': {
     kebabName: '${s.kebabName}',
@@ -186,6 +184,8 @@ ${stories.map(s => `  '${s.kebabName}': {
     }
 
     nuxt.hook('components:extend', async (components) => {
+      logger.warn('components:extend')
+
       const storyComponents = components.filter(c =>
         c.pascalName.endsWith('Story') && c.pascalName !== 'Story',
       )
@@ -226,10 +226,12 @@ ${stories.map(s => `  '${s.kebabName}': {
       }))
 
       // Only update if the stories have changed
-      if (JSON.stringify(stories) !== JSON.stringify(newStories)) {
+      // if (JSON.stringify(stories) !== JSON.stringify(newStories)) {
+      if (stories.length !== newStories.length) {
         logger.info(`Found ${storyComponents.length} story components`)
         stories.length = 0 // Clear the array
         stories.push(...newStories)
+        logger.warn('Updating templates')
         await updateTemplates({
           filter: template => template.filename === 'stories.mjs',
         })

--- a/src/module.ts
+++ b/src/module.ts
@@ -184,8 +184,6 @@ ${stories.map(s => `  '${s.kebabName}': {
     }
 
     nuxt.hook('components:extend', async (components) => {
-      logger.warn('components:extend')
-
       const storyComponents = components.filter(c =>
         c.pascalName.endsWith('Story') && c.pascalName !== 'Story',
       )
@@ -231,7 +229,6 @@ ${stories.map(s => `  '${s.kebabName}': {
         logger.info(`Found ${storyComponents.length} story components`)
         stories.length = 0 // Clear the array
         stories.push(...newStories)
-        logger.warn('Updating templates')
         await updateTemplates({
           filter: template => template.filename === 'stories.mjs',
         })

--- a/src/module.ts
+++ b/src/module.ts
@@ -136,7 +136,7 @@ ${stories.map(s => `  '${s.kebabName}': {
     pascalName: '${s.pascalName}',
     shortPath: '${s.shortPath}',
     filePath: '${s.filePath}',
-    component: ${s.pascalName},
+    component: () => import('${s.filePath}'),
     template: ${JSON.stringify(s.template)},
     variants: ${JSON.stringify(s.variants)},
     hasVariants: ${s.hasVariants},

--- a/src/runtime/pages/story-view.vue
+++ b/src/runtime/pages/story-view.vue
@@ -5,7 +5,10 @@
         v-if="story"
         class="story-content"
       >
-        <component :is="story.component" />
+        <component
+          :is="storyComponent"
+          v-if="storyComponent"
+        />
       </div>
       <div
         v-else
@@ -18,15 +21,20 @@
 </template>
 
 <script setup lang="ts">
+import { defineAsyncComponent } from 'vue'
 import { useStory } from '../composables/useStory'
 import StoriesLayout from '../layouts/stories.vue'
 // @ts-expect-error resolved at runtime
 import { useHead, useRoute } from '#imports'
 
 const route = useRoute()
-const { stories } = useStory()
+const { getStoryDetails } = useStory()
 
-const story = stories[route.params.slug as string]
+const story = getStoryDetails(route.params.slug as string)
+
+const storyComponent = story?.component
+  ? defineAsyncComponent(story.component)
+  : null
 
 useHead({
   title: story ? story.pascalName : 'Story Not Found',

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -5,7 +5,7 @@ export interface BedtimeStory {
   pascalName: string
   shortPath: string
   filePath: string
-  component?: Component
+  component?: () => Promise<Component>
   template?: string
   variants?: Record<string, BedtimeVariant>
   hasVariants?: boolean


### PR DESCRIPTION
By loading story components asynchronously, and not importing them in the stories.mjs virtual file, we avoid reloading everything whenever a story component is touched.
